### PR TITLE
Ipcc patch3

### DIFF
--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -338,6 +338,10 @@ for scenario in scenarios:
             var['Final Energy|Residential and Commercial|Residential|Heating|Electric boilers'] = - MWh2EJ * (n.links_t.p1.filter(like ='resistive heater').filter(like='residentioal').filter(like =country).sum().sum())
             var['Final Energy|Gas|Synthetic'] = - MWh2EJ*n.links_t.p1.filter(like ='Sabatier').filter(like =country).sum().sum()
             
+            #Agriculture demand
+            
+            var['Agricultural Demand|Crops|Energy']= MWh2EJ*h*(n.loads_t.p.filter(like ='agriculture').filter(like =country).sum().sum())    
+
             """
             Capital cost and Lifetime 
             """

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -303,7 +303,7 @@ for scenario in scenarios:
                              if i==0 :  var['Final Energy|Industry|'+industry+'|'+v_type]=0   #skips electricity
                              if industry_name in prod.columns:   #skips some variables that are in newer networks
                                  var['Final Energy|Industry|'+industry+'|'+v_type]+= (   
-                                 ratios[industry_name][v_name]*prod[industry_name].filter(like=country).sum)   
+                                 ratios[industry_name][v_name]*prod[industry_name].filter(like=country).sum())   
   
             var['Final Energy|Industry|Electricity']=MWh2EJ*h*(n.loads_t.p.filter(like ='industry electricity').filter(like =country).sum().sum())    
             var['Final Energy|Industry|Gases|Fossil'] = MWh2EJ*industry_demand['methane'].filter(like=country).sum()  

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -179,10 +179,8 @@ for scenario in scenarios:
                #MWh to GWh
                var[v_type+'|Electricity|Storage|Pumped Hydro Storage'] = MW2GW*(n.storage_units.p_nom_opt.filter(like ='PHS').filter(like =country).filter(like=str(dict_var[v_type]))*
                                                                                n.storage_units.max_hours.filter(like ='PHS').filter(like =country).filter(like=str(dict_var[v_type]))).sum()
-               var[v_type+'|Electricity|Storage|Battery Capacity|Home Battery'] =MW2GW*((n.links.efficiency.filter(like ='home battery charger').filter(like =country).filter(like=str(dict_var[v_type]))
-                 *n.links.p_nom_opt.filter(like ='home battery charger').filter(like =country).filter(like=str(dict_var[v_type]))).sum())
-               var[v_type+'|Electricity|Storage|Battery Capacity'] = MW2GW*((n.links.efficiency.filter(like ='battery charger').filter(like =country).filter(like=str(dict_var[v_type]))
-                 *n.links.p_nom_opt.filter(like ='battery charger').filter(like =country).filter(like=str(dict_var[v_type]))).sum())
+               var[v_type+'|Electricity|Storage|Battery Capacity|Home Battery'] =MW2GW*((n.stores.e_nom_opt.filter(like ='home battery').filter(like =country).filter(like=str(dict_var[v_type]))).sum())
+               var[v_type+'|Electricity|Storage|Battery Capacity'] = MW2GW*((n.stores.e_nom_opt.filter(like ='battery').filter(like =country).filter(like=str(dict_var[v_type]))).sum())
                var[v_type+'|Electricity|Storage|Battery Capacity|Utility-scale Battery'] = (var[v_type+'|Electricity|Storage|Battery Capacity'] 
                  - var[v_type+'|Electricity|Storage|Battery Capacity|Home Battery'])
                #var[v_type+'|Electricity|Storage|Hydrogen Storage Capacity|overground'] = MW2GW *(n.stores.e_nom_opt.filter(like ='H2').filter(like =country).filter(like=str(dict_var[v_type])).sum()/168) #assume one week charge time for H2 storage
@@ -193,11 +191,7 @@ for scenario in scenarios:
                var[v_type+'|Storage|Thermal Energy Storage|District heating storage'] = n.stores.e_nom_opt.filter(like ='central water tank').filter(like =country).filter(like=str(dict_var[v_type])).sum()/(180*24)  #3 day for house and 180 day for rural water tank  charge
                var[v_type+'|Storage|Thermal Energy Storage'] = var[v_type+'|Storage|Thermal Energy Storage|Household storage'] + var[v_type+'|Storage|Thermal Energy Storage|District heating storage']
                
-               #MW to GW                                                             
-               var[v_type+'|Electricity|Storage Capacity'] = MW2GW* (n.storage_units.p_nom_opt.filter(like ='PHS').filter(like =country).filter(like=str(dict_var[v_type])).sum()   #PHS+battery+hydrogen
-                                                            + ((n.links.efficiency.filter(like ='battery charger').filter(like =country).filter(like=str(dict_var[v_type]))
-                                                                *n.links.p_nom_opt.filter(like ='battery charger').filter(like =country).filter(like=str(dict_var[v_type]))).sum())
-                                                            + (n.links.p_nom_opt.filter(like ='Fuel Cell').filter(like =country).filter(like=str(dict_var[v_type])).sum()))                                  
+                  
                """
                Capacity : grid, peak , other
                """

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -414,12 +414,15 @@ for scenario in scenarios:
                                          n.links.capital_cost.filter(like='coal CC').filter(like=str(year)).filter(like=country)).sum()
             var['Investment|Energy Supply|Electricity|Coal|w/o CCS'] = (n.links.p_nom_opt.filter(like='coal').filter(like=str(year)).filter(like=country)*
                                          n.links.capital_cost.filter(like='coal').filter(like=str(year)).filter(like=country)).sum()
-            var['Investment|Energy Supply|Electricity|Electricity Storage'] = (n.links.p_nom_opt.filter(like='coal').filter(like=str(year)).filter(like=country)*
-                                         n.links.capital_cost.filter(like='coal').filter(like=str(year)).filter(like=country)).sum()
-            var['Investment|Energy Supply|Electricity|Fossil'] = (n.links.p_nom_opt.filter(like='coal').filter(like=str(year)).filter(like=country)*
-                                         n.links.capital_cost.filter(like='coal').filter(like=str(year)).filter(like=country)).sum()
+            var['Investment|Energy Supply|Electricity|Electricity Storage'] = ((n.links.p_nom_opt.filter(like='battery').filter(like=str(year)).filter(like=country)*
+                                         n.links.capital_cost.filter(like='battery').filter(like=str(year)).filter(like=country)).sum()+
+                                         (n.stores.e_nom_opt.filter(like='battery').filter(like=str(year)).filter(like=country)*
+                                         n.stores.capital_cost.filter(like='battery').filter(like=str(year)).filter(like=country)).sum())
             var['Investment|Energy Supply|Electricity|Gas'] = (n.links.p_nom_opt.filter(like='CGT').filter(like=str(year)).filter(like=country)*
                                          n.links.capital_cost.filter(like='CGT').filter(like=str(year)).filter(like=country)).sum()
+            var['Investment|Energy Supply|Electricity|Fossil'] = (var['Investment|Energy Supply|Electricity|Coal|w/ CCS']
+                                                               + var['Investment|Energy Supply|Electricity|Coal|w/o CCS']
+                                                               + var['Investment|Energy Supply|Electricity|Gas'] )
             var['Investment|Energy Supply|Electricity|Hydro'] =((n.generators.p_nom_opt.filter(like='ror').filter(like=str(year)).filter(like=country)*
                                          n.generators.capital_cost.filter(like='ror').filter(like=str(year)).filter(like=country)).sum()+
                                          (n.links.p_nom_opt.filter(like='hydro').filter(like=str(year)).filter(like=country)*

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -10,6 +10,10 @@ import pandas as pd
 import yaml
 from itertools import product
 
+MWh2EJ=3.6e-9     #convert MWh to EJ
+TWh2TJ=3.6e+3   #convert TWh to TJ
+MW2GW=0.001
+
 # Read the pypsa-eur-sec config file
 with open('config.yaml') as yamlfile:
     config = yaml.load(yamlfile,Loader=yaml.FullLoader)
@@ -25,7 +29,6 @@ literature_reference = "Pedersen, T. T., Gøtske, E. K., Dvorak, A., Andresen, G
 sector_opts = config['scenario']['sector_opts']
 
 
-wind_split = ['DE', 'ES', 'FI', 'FR', 'GB', 'IT', 'NO', 'PL', 'RO', 'SE']
 
 keys, values = zip(*config['scenario'].items())
 permutations_dicts = [dict(zip(keys, v)) for v in product(*values)]
@@ -77,6 +80,25 @@ iso2name={'AT':'Austria',
           'SK':'Slovakia',
           'IE':'Ireland',
           'NL':'The Netherlands',}
+
+dict_industry= {
+   'Cement':['Cement'],
+   'Chemicals|Ammonia':['Ammonia'],
+   'Chemicals|High value chemicals': ['HVC'],
+   'Chemicals|Methanol':['Methanol'],
+   'Chemicals|Other': ['Other chemicals'],
+   'Non-ferrous metals':['Aluminium - primary production','Aluminium - secondary production','Other non-ferrous metals'],
+   'Other': ['Other Industrial Sectors'],
+   'Pulp and Paper' : ['Pulp production','Paper production'],
+   'Steel' :['Electric arc','DRI + Electric arc','Integrated steelworks']}
+
+industry_inputs= {
+    'Electricity':['elec'],
+    'Gases|Fossil':['methane'],
+    'Heat':['heat'],
+    'Hydrogen':['hydrogen'],
+    'Liquids|Fossil':['naphtha'],
+    'Solids':['coal','coke','biomass']}
 
 for scenario in scenarios:
     #one excel file per scenario

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -301,7 +301,7 @@ for scenario in scenarios:
                      for v_type in industry_inputs.keys():
                          for i, v_name in enumerate(industry_inputs[v_type]):
                              if i==0 :  var['Final Energy|Industry|'+industry+'|'+v_type]=0   #skips electricity
-                             if 'industry_name' in prod.columns:   #skips some variables that are in newer networks
+                             if industry_name in prod.columns:   #skips some variables that are in newer networks
                                  var['Final Energy|Industry|'+industry+'|'+v_type]+= (   
                                  ratios[industry_name][v_name]*prod[industry_name].filter(like=country).sum)   
   

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -116,7 +116,7 @@ for scenario in scenarios:
             ds = file['data' + str(i)] 
             var={}
             
-            dict_var={'Capacity':' ', 'Capacity Additions':year}      
+            dict_var={'Cumulative Capacity':' ', 'Capacity':' ', 'Capacity Additions':year, }      
             for v_type in dict_var.keys():
                """
                Capacity : Solar PV, onshore and offshore wind
@@ -508,6 +508,13 @@ for scenario in scenarios:
 
             for v in var.keys():
                 ro=[r for r in ds['D'] if r.value==v][0].row
+
+                if 'Cumulative Capacity' in v:
+                    col_last=[c for c in ds[1] if c.value==years[years.index(year)-1]][0].column   
+                    if year != years[0]:    
+                        var[v] = (ds.cell(row=ro, column=col_last).value +
+                                  var[v.replace('Cumulative Capacity','Capacity Additions')] )
+                        
                 ds.cell(row=ro, column=col).value = round(var[v],3) 
                 ds.cell(row=ro, column=1).value = model
                 ds.cell(row=ro, column=2).value = scenario
@@ -527,4 +534,3 @@ for scenario in scenarios:
  
         
     file.save(f"{output_folder}IPCC_AR6_{scenario}_new.xlsx")
-

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -507,6 +507,7 @@ for scenario in scenarios:
 
 
             for v in var.keys():
+              if [r for r in ds['D'] if r.value==v]:         
                 ro=[r for r in ds['D'] if r.value==v][0].row
 
                 if 'Cumulative Capacity' in v:

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -104,14 +104,17 @@ for scenario in scenarios:
     #one excel file per scenario
     file = openpyxl.load_workbook(template_path)
     ds = file['data'] #data sheet
+    ratios = pd.read_csv("resources/industry_sector_ratios.csv",index_col=0,header=0,)
+
     for year in years:
         n = pypsa.Network(f"postnetworks/{scenario}{year}.nc")
         costs = pd.read_csv(f"costs/costs_{year}.csv", index_col=[0,1])
-        
+        prod = pd.read_csv("resources/industrial_production_elec_s_37_{}.csv".format(year),index_col=0,header=0,)  #s_37 ?? 
+        industry_demand=pd.read_table('resources/industrial_energy_demand_elec_s370_37m_{}.csv'.format(year),delimiter=',',index_col=0)
         col=[c for c in ds[1] if c.value==year][0].column
         
         for i,country in enumerate(countries):
-            if year == 2020:
+            if year == years[0]:
                 #one datasheet per country including information from different years
                 target = file.copy_worksheet(file['data'])
                 target.title ='data' + str(i)

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -10,6 +10,13 @@ import pandas as pd
 import yaml
 from itertools import product
 
+def safe_div(n, d):
+ """
+ Only divides if the divisor is not zero, otherwise returns zero.
+ """ 
+ return n / d if d else 0
+
+
 MWh2EJ=3.6e-9     #convert MWh to EJ
 t2Mt=1e-6       # convert tonnes to Mtonnes
 MW2GW=0.001       # convert MW/MWh to GW/GWh

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -466,14 +466,51 @@ for scenario in scenarios:
 
 
             """
-            Emissions and Carbon intensity for industry (MtCO2)   #carbon intensity or emissions
+            Emissions (MtCO2)   
             """
-             
+            
+            
+            #Emissions :  
+            #CHP emissions are calculated based on share of electricity and heat:
+
+            var['Emissions|CO2|Energy|Supply|Electricity'] = (1e-6)*(-1)*h*(
+                n.links_t.p2.filter(like ='lignite').filter(like =country).sum().sum()+
+                n.links_t.p2.filter(like ='coal').filter(like =country).sum().sum() +
+                n.links_t.p2.filter(like ='oil-').filter(like =country).sum().sum()+
+                n.links_t.p2.filter(like ='OCGT').filter(like =country).sum().sum()+
+                n.links_t.p2.filter(like ='CCGT').filter(like =country).sum().sum()+
+                safe_div(n.links_t.p3.filter(like ='gas CHP').filter(like =country).sum().sum()
+                       *n.links_t.p1.filter(like ='gas CHP').filter(like =country).sum().sum()             
+                       ,n.links_t.p1.filter(like ='gas CHP').filter(like =country).sum().sum()+
+                         n.links_t.p2.filter(like ='gas CHP').filter(like =country).sum().sum())+ 
+                safe_div(n.links_t.p3.filter(like ='solid biomass CHP').filter(like =country).sum().sum()
+                        *n.links_t.p1.filter(like ='solid biomass CHP').filter(like =country).sum().sum()            
+                        ,n.links_t.p1.filter(like ='solid biomass CHP').filter(like =country).sum().sum()+
+                       n.links_t.p2.filter(like ='solid biomass CHP').filter(like =country).sum().sum())) 
+
+            
+            var['Emissions|CO2|Energy|Supply|Gases']  = (1e-6)*(-1)*h*(
+                n.links_t.p2.filter(like ='SMR').filter(like =country)).sum().sum()
+                        
+            var['Emissions|CO2|Energy|Supply|Heat'] = (1e-6)*(-1)*h*(
+                 n.links_t.p2.filter(like ='oil boiler').filter(like =country).sum().sum()+ 
+                 n.links_t.p2.filter(like ='gas boiler').filter(like =country).sum().sum()+
+                 safe_div(n.links_t.p3.filter(like ='gas CHP').filter(like =country).sum().sum()
+                            *n.links_t.p2.filter(like ='gas CHP').filter(like =country).sum().sum()            
+                             ,n.links_t.p1.filter(like ='gas CHP').filter(like =country).sum().sum()+
+                             n.links_t.p2.filter(like ='gas CHP').filter(like =country).sum().sum())+
+                 safe_div(n.links_t.p3.filter(like ='solid biomass CHP').filter(like =country).sum().sum()
+                           *n.links_t.p2.filter(like ='solid biomass CHP').filter(like =country).sum().sum()            
+                           ,n.links_t.p1.filter(like ='solid biomass CHP').filter(like =country).sum().sum()+
+                             n.links_t.p2.filter(like ='solid biomass CHP').filter(like =country).sum().sum())) 
             
             var['Emissions|CO2|Energy|Supply']=(-1)*t2Mt*(n.links_t.p1[[i for i in n.links.index if 'co2 atm' in n.links.bus1[i] and country in i]].sum().sum()
-                                     +n.links_t.p2[[i for i in n.links.index if 'co2 atm' in n.links.bus2[i] and 'nuclear' not in i and country in i]].sum().sum()
-                                     +n.links_t.p3[[ i for i in n.links.index if 'co2 atm' in n.links.bus3[i] and country in i]].sum().sum())
-
+                  +n.links_t.p2[[i for i in n.links.index if 'co2 atm' in n.links.bus2[i] and 'nuclear' not in i and country in i]].sum().sum()
+                   +n.links_t.p3[[ i for i in n.links.index if 'co2 atm' in n.links.bus3[i] and country in i]].sum().sum())
+            
+            """
+            Carbon intensity for industry (MtCO2)   
+            """
             var['Carbon Intensity|Production|Cement']=t2Mt*ratios['Cement']['process emission']*prod['Cement'].filter(like=country).sum()
             var['Carbon Intensity|Production|Chemicals|Ammonia']=t2Mt*ratios['Ammonia']['process emission']*prod['Ammonia'].filter(like=country).sum()
             if 'HVC' in prod.columns: var['Carbon Intensity|Production|Chemicals|High value chemicals']=(t2Mt*ratios['HVC']['process emission']*prod['HVC'].filter(like=country).sum()+

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -440,6 +440,14 @@ for scenario in scenarios:
             var['Investment|Energy Supply|Hydrogen|Fossil'] =  (n.links.p_nom_opt.filter(like='SMR').filter(like=str(year)).filter(like=country)*
                                          n.links.capital_cost.filter(like='SMR').filter(like=str(year)).filter(like=country)).sum()
 
+            
+            """
+            Price of energy
+            """
+            var['Discount rate|Economy']= config['costs']['discountrate']
+            var['price|Final Energy|Residential and Commercial|Residential|Electricity']= n.buses_t.marginal_price.filter(like='low voltage').filter(like=country).mean()
+            var['price|Final Energy|Residential and Commercial|Residential|Gases|Natural Gas']= n.buses_t.marginal_price.filter(like='EU gas').mean()
+            var['price|Final Energy|Transportation|Hydrogen']= n.buses_t.marginal_price.filter(like='H2').filter(like=country).mean()
 
             """
             Efficiency

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -485,7 +485,7 @@ for scenario in scenarios:
             #Emissions :  
             #CHP emissions are calculated based on share of electricity and heat:
 
-            var['Emissions|CO2|Energy|Supply|Electricity'] = (1e-6)*(-1)*h*(
+            var['Emissions|CO2|Energy|Supply|Electricity'] = t2Mt*(-1)*h*(
                 n.links_t.p2.filter(like ='lignite').filter(like =country).sum().sum()+
                 n.links_t.p2.filter(like ='coal').filter(like =country).sum().sum() +
                 n.links_t.p2.filter(like ='oil-').filter(like =country).sum().sum()+
@@ -501,10 +501,10 @@ for scenario in scenarios:
                        n.links_t.p2.filter(like ='solid biomass CHP').filter(like =country).sum().sum())) 
 
             
-            var['Emissions|CO2|Energy|Supply|Gases']  = (1e-6)*(-1)*h*(
+            var['Emissions|CO2|Energy|Supply|Gases']  = t2Mt*(-1)*h*(
                 n.links_t.p2.filter(like ='SMR').filter(like =country)).sum().sum()
                         
-            var['Emissions|CO2|Energy|Supply|Heat'] = (1e-6)*(-1)*h*(
+            var['Emissions|CO2|Energy|Supply|Heat'] = t2Mt*(-1)*h*(
                  n.links_t.p2.filter(like ='oil boiler').filter(like =country).sum().sum()+ 
                  n.links_t.p2.filter(like ='gas boiler').filter(like =country).sum().sum()+
                  safe_div(n.links_t.p3.filter(like ='gas CHP').filter(like =country).sum().sum()

--- a/pypsa_to_IPCC.py
+++ b/pypsa_to_IPCC.py
@@ -109,7 +109,7 @@ for scenario in scenarios:
     for year in years:
         n = pypsa.Network(f"postnetworks/{scenario}{year}.nc")
         costs = pd.read_csv(f"costs/costs_{year}.csv", index_col=[0,1])
-        prod = pd.read_csv("resources/industrial_production_elec_s_37_{}.csv".format(year),index_col=0,header=0,)  #s_37 ?? 
+        prod = pd.read_csv("resources/industrial_production_elec_s_37_{}.csv".format(year),index_col=0,header=0,)  #s_37  
         industry_demand=pd.read_table('resources/industrial_energy_demand_elec_s370_37m_{}.csv'.format(year),delimiter=',',index_col=0)
         col=[c for c in ds[1] if c.value==year][0].column
         
@@ -303,7 +303,7 @@ for scenario in scenarios:
                              var['Final Energy|Industry|'+industry+'|'+v_type]+=ratios[industry_name][v_name]*prod[industry_name].filter(like=country).sum()
   
             var['Final Energy|Industry|Electricity']=MWh2EJ*h*(n.loads_t.p.filter(like ='industry electricity').filter(like =country).sum().sum())    
-            var['Final Energy|Industry|Gases|Fossil'] = MWh2EJ*industry_demand['methane'].filter(like=country).sum()  #other sectors that use gas??
+            var['Final Energy|Industry|Gases|Fossil'] = MWh2EJ*industry_demand['methane'].filter(like=country).sum()  
             var['Final Energy|Industry|Heat']=MWh2EJ*h*(n.loads_t.p.filter(like ='low-temperature heat for industry').filter(like =country).sum().sum())
             var['Final Energy|Industry|Hydrogen']=MWh2EJ*h*(n.loads_t.p.filter(like ='H2 for industry').filter(like =country).sum().sum())
             var['Final Energy|Industry|Liquids|Oil']= MWh2EJ*industry_demand['naphtha'].filter(like=country).sum()
@@ -483,9 +483,9 @@ for scenario in scenarios:
             var['Carbon Intensity|Production|Chemicals|Other']=t2Mt*ratios['Other chemicals']['process emission']*prod['Other chemicals'].filter(like=country).sum()
             var['Carbon Intensity|Production|Non-ferrous metals']=(t2Mt*ratios['Aluminium - primary production']['process emission']*prod['Aluminium - primary production'].filter(like=country).sum()+
                    t2Mt*ratios['Other non-ferrous metals']['process emission']*prod['Other non-ferrous metals'].filter(like=country).sum())/2
-            var['Carbon Intensity|Production|Other']=t2Mt*ratios['Other Industrial Sectors']['process emission']*prod['Other Industrial Sectors'].filter(like=country).sum()  #not really all the others??
+            var['Carbon Intensity|Production|Other']=t2Mt*ratios['Other Industrial Sectors']['process emission']*prod['Other Industrial Sectors'].filter(like=country).sum()  
             var['Carbon Intensity|Production|Pulp and Paper']=(t2Mt*ratios['Pulp production']['process emission']*prod['Pulp production'].filter(like=country).sum()+
-                  t2Mt*ratios['Paper production']['process emission']*prod['Paper production'].filter(like=country).sum())/2  #It's zero ??
+                  t2Mt*ratios['Paper production']['process emission']*prod['Paper production'].filter(like=country).sum())/2  
             var['Carbon Intensity|Production|Steel']=(t2Mt*ratios['Electric arc']['process emission']*prod['Electric arc'].filter(like=country).sum()
                  +t2Mt*ratios['DRI + Electric arc']['process emission']*prod['DRI + Electric arc'].filter(like=country).sum()
                  +t2Mt*ratios['Integrated steelworks']['process emission']*prod['Integrated steelworks'].filter(like=country).sum())/3
@@ -495,7 +495,7 @@ for scenario in scenarios:
             """
             var['Carbon Sequestration|CCS|Biomass']=t2Mt*h*n.links_t.p4.filter(like='biomass CHP CC').filter(like=country).sum().sum()
             var['Carbon Sequestration|CCS|Fossil']=t2Mt*h*(-1)*(n.links_t.p3.filter(like='gas CHP CC').filter(like=country).sum().sum()
-                                        +n.links_t.p4.filter(like='gas CHP CC').filter(like=country).sum().sum())  #??
+                                        +n.links_t.p4.filter(like='gas CHP CC').filter(like=country).sum().sum()) 
             var['Carbon Sequestration|CCS|Industrial Processes']=t2Mt*h*(-1)*n.links_t.p3.filter(like='SMR CC').filter(like=country).sum().sum()
             var['Carbon Sequestration|Direct Air Capture']=t2Mt*h*n.links_t.p0.filter(like='DAC').filter(like=country).sum().sum()
             var['Carbon Sequestration|CCS']=(var['Carbon Sequestration|CCS|Biomass']
@@ -504,7 +504,7 @@ for scenario in scenarios:
                                  +var['Carbon Sequestration|Direct Air Capture'])
             var['Carbon Utilization|CCS|Industry']= t2Mt*h*(n.links_t.p2.filter(like='Sabatier').filter(like=country).sum().sum()
                                                     +n.links_t.p2.filter(like='helmeth').filter(like=country).sum().sum()
-                                                     +n.links_t.p2.filter(like='Fischer-Tropsch').filter(like=country).sum().sum()) #?? 
+                                                     +n.links_t.p2.filter(like='Fischer-Tropsch').filter(like=country).sum().sum()) 
 
 
             for v in var.keys():


### PR DESCRIPTION
Hi @martavp and @TimToernes ,
 This pull request includes changes that solve some of the current issues such as the filtering method and adding variables like 'added capacity' (I will also answer each issue separately). 
I've added many variables, and the next step is to use the Config file to filter which variables should be calculated for each network. Currently the script writes all the variables to the excel, so even if for example 'industry' is not in the network, all variables related to it will be '0' in the output table, which could be misleading. 
Other comments:
- The variables definitely need some checking. I will try to do this myself and would appreciate any feedback on wether some calculations/numbers/units don't seem correct.
-  I am still trying to find an efficient way to add 'Cumulative capacity' variables to the script.
-  There is some overlap between 'carbon intensity' and 'carbon emissions'. Currently I have only added 'Carbon intensity' since the emissions are divided between specific gases (CO2, Nox, etc.), but there is no variable for equivalent carbon emissions, which I believe is closest to the number calculated by PyPSA.
-  'Agriculture' related variables are not yet added.
-  'Primary energy' is not included yet.